### PR TITLE
SC65554: App must store issue metadata when issues are linked to Deskpro tickets

### DIFF
--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -1,7 +1,7 @@
 import {FC, useEffect, useState} from "react";
 import {CreateLinkIssue} from "../components/CreateLinkIssue/CreateLinkIssue";
 import {IssueForm} from "../components/IssueForm/IssueForm";
-import {addLinkCommentToIssue, createIssue} from "../context/StoreProvider/api";
+import {addLinkCommentToIssue, createIssue, getIssueByKey} from "../context/StoreProvider/api";
 import {useDeskproAppClient} from "@deskpro/app-sdk";
 import {IssueFormData, InvalidRequestResponseError} from "../context/StoreProvider/types";
 import {useLoadLinkedIssues, useSetAppTitle} from "../hooks";
@@ -32,12 +32,14 @@ export const Create: FC = () => {
         setApiErrors({});
 
         createIssue(client, data, meta)
-            .then(({ key }) => {
-                client
+            .then(({ key }) => getIssueByKey(client, key))
+            .then(async (issue) => {
+                await client
                     .getEntityAssociation("linkedJiraIssues", state.context?.data.ticket.id as string)
-                    .set(key);
+                    .set(issue.key, issue)
+                ;
 
-                return key;
+                return issue.key;
             })
             .then((key) => addLinkCommentToIssue(
                 client,

--- a/src/pages/Edit.tsx
+++ b/src/pages/Edit.tsx
@@ -73,6 +73,14 @@ export const Edit: FC<EditProps> = ({ issueKey }: EditProps) => {
         setApiErrors({});
 
         updateIssue(client, issueKey, data, meta)
+            .then(async () => {
+                const issue = await getIssueByKey(client, issueKey);
+
+                return client
+                    .getEntityAssociation("linkedJiraIssues", state.context?.data.ticket.id as string)
+                    .set(issueKey, issue)
+                ;
+            })
             .then(() => loadIssues())
             .then(() => {
                 setLoading(false);

--- a/src/pages/Link.tsx
+++ b/src/pages/Link.tsx
@@ -14,7 +14,7 @@ import { useDebouncedCallback } from "use-debounce";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useLoadLinkedIssues, useSetAppTitle } from "../hooks";
 import { SearchResultItem } from "../components/SearchResultItem/SearchResultItem";
-import { addLinkCommentToIssue, searchIssues } from "../context/StoreProvider/api";
+import {addLinkCommentToIssue, getIssueByKey, searchIssues} from "../context/StoreProvider/api";
 import {CreateLinkIssue} from "../components/CreateLinkIssue/CreateLinkIssue";
 
 export const Link: FC = () => {
@@ -76,10 +76,14 @@ export const Link: FC = () => {
 
     setIsLinkIssuesLoading(true);
 
-    const updates = selected.map((key: string) => client
-      .getEntityAssociation("linkedJiraIssues", state.context?.data.ticket.id as string)
-      .set(key)
-    );
+    const updates = selected.map(async (key: string) => {
+      const issue = await getIssueByKey(client, key);
+
+      return client
+          .getEntityAssociation("linkedJiraIssues", state.context?.data.ticket.id as string)
+          .set(key, issue)
+      ;
+    });
 
     updates.push(...selected.map((key: string) => addLinkCommentToIssue(
         client,


### PR DESCRIPTION
When a JIRA issue is linked, created or edited via the app, we need to:

- Store issue metadata along with the Deskpro custom field
- Store issue field values along with the Deskpro custom field

All field values and metadata are stored in the Deskpro `custom_*_props` tables

---

Link to Shortcut: https://app.shortcut.com/deskpro/story/65554/jira-app-must-store-issue-metadata-when-issues-are-linked-to-deskpro-tickets