### PR TITLE
SC62697: Allow users to add comments to a JIRA issue from Deskpro reply box notes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "@deskpro/jira",
   "title": "JIRA",
   "description": "View JIRA issues associated with a Deskpro ticket",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "scope": "agent",
   "isSingleInstall": true,
   "hasDevMode": true,

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "@deskpro/jira",
   "title": "JIRA",
   "description": "View JIRA issues associated with a Deskpro ticket",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "scope": "agent",
   "isSingleInstall": true,
   "hasDevMode": true,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@atlaskit/adf-utils": "14.4.0",
-    "@deskpro/app-sdk": "^0.1.23",
+    "@deskpro/app-sdk": "^0.2.30",
     "@types/html-truncate": "^1.2.2",
     "date-fns": "^2.28.0",
     "html-truncate": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@atlaskit/adf-utils": "14.4.0",
-    "@deskpro/app-sdk": "^0.1.17",
+    "@deskpro/app-sdk": "^0.1.23",
     "@types/html-truncate": "^1.2.2",
     "date-fns": "^2.28.0",
     "html-truncate": "^1.2.2",

--- a/src/components/CreateLinkIssue/CreateLinkIssue.tsx
+++ b/src/components/CreateLinkIssue/CreateLinkIssue.tsx
@@ -15,7 +15,7 @@ export const CreateLinkIssue: FC<CreateLinkIssueProps> = ({ selected }: CreateLi
   return (
     <Stack className="create-link" justify="space-between" align="center" style={{ backgroundColor: colors.grey10 }}>
       <Button
-        text="Find Story"
+        text="Find Issue"
         intent="secondary"
         icon={faSearch}
         size="large"

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -70,6 +70,7 @@ export const Main: FC = () => {
 
   useInitialisedDeskproAppClient((client) => {
     registerReplyBoxNotesAdditionsTargetAction(client, state);
+    client.registerTargetAction("jiraOnReplyBoxNote", "on_reply_box_note");
   }, [state.linkedIssuesResults?.list, state?.context?.data]);
 
   useDeskproAppEvents({

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,3 +118,7 @@ export interface ReplyBoxNoteSelection {
     id: string;
     selected: boolean;
 }
+
+export interface ReplyBoxOnReply {
+    note: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,3 +113,8 @@ export type IssueMeta = {
         autoCompleteUrl: string;
     }
 ;
+
+export interface ReplyBoxNoteSelection {
+    id: string;
+    selected: boolean;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 import { parseISO } from "date-fns";
+import {State} from "./context/StoreProvider/types";
+import {IDeskproClient} from "@deskpro/app-sdk";
 
 export const getDateFromValue = (value: unknown): Date => {
     if (typeof value === "string") {
@@ -16,3 +18,30 @@ export const getDateFromValue = (value: unknown): Date => {
         throw new Error();
     }
 };
+
+export const registerReplyBoxNotesAdditionsTargetAction = (client: IDeskproClient, state: State) => {
+    const ticketId = state?.context?.data.ticket.id;
+    const linkedIssues = (state.linkedIssuesResults?.list ?? []);
+
+    if (!ticketId) {
+        return;
+    }
+
+    Promise
+        .all(linkedIssues.map((issue) => client.getUserState<boolean>(ticketReplyNotesSelectionStateKey(ticketId, issue.id))))
+        .then((flags) => {
+            client.registerTargetAction("jiraReplyBoxNoteAdditions", "reply_box_note_item_selection", {
+                payload: {
+                    linkedIssues: (state.linkedIssuesResults?.list ?? []).map((issue, idx) => ({
+                        id: issue.id,
+                        key: issue.key,
+                        summary: issue.summary,
+                        selected: flags[idx][0]?.data ?? false,
+                    })),
+                },
+            });
+        })
+    ;
+};
+
+export const ticketReplyNotesSelectionStateKey = (ticketId: string, issueId: string|number) => `tickets/${ticketId}/notes/selection/${issueId}`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,13 +28,14 @@ export const registerReplyBoxNotesAdditionsTargetAction = (client: IDeskproClien
     }
 
     Promise
-        .all(linkedIssues.map((issue) => client.getUserState<boolean>(ticketReplyNotesSelectionStateKey(ticketId, issue.id))))
+        .all(linkedIssues.map((issue) => client.getState<{ selected: boolean }>(ticketReplyNotesSelectionStateKey(ticketId, issue.id))))
         .then((flags) => {
             client.registerTargetAction("jiraReplyBoxNoteAdditions", "reply_box_note_item_selection", {
+                title: "JIRA Issues",
                 payload: (state.linkedIssuesResults?.list ?? []).map((issue, idx) => ({
                     id: issue.id,
                     title: issue.key,
-                    selected: flags[idx][0]?.data ?? false,
+                    selected: flags[idx][0]?.data?.selected ?? false,
                 })),
             });
         })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,14 +31,11 @@ export const registerReplyBoxNotesAdditionsTargetAction = (client: IDeskproClien
         .all(linkedIssues.map((issue) => client.getUserState<boolean>(ticketReplyNotesSelectionStateKey(ticketId, issue.id))))
         .then((flags) => {
             client.registerTargetAction("jiraReplyBoxNoteAdditions", "reply_box_note_item_selection", {
-                payload: {
-                    linkedIssues: (state.linkedIssuesResults?.list ?? []).map((issue, idx) => ({
-                        id: issue.id,
-                        key: issue.key,
-                        summary: issue.summary,
-                        selected: flags[idx][0]?.data ?? false,
-                    })),
-                },
+                payload: (state.linkedIssuesResults?.list ?? []).map((issue, idx) => ({
+                    id: issue.id,
+                    title: issue.key,
+                    selected: flags[idx][0]?.data ?? false,
+                })),
             });
         })
     ;

--- a/yarn.lock
+++ b/yarn.lock
@@ -384,10 +384,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@deskpro/app-sdk@^0.1.23":
-  version "0.1.23"
-  resolved "https://registry.yarnpkg.com/@deskpro/app-sdk/-/app-sdk-0.1.23.tgz#e03f1fb3d99c8fde02227bf74229781554dd8299"
-  integrity sha512-4G0FsECqkWMeWuBvSQOCpNBJEV6D6+ytnWeT4KRzihP1bUxneUAoODHhyM0hfyInkqBvEggMRHBCEbsQz3Kd4w==
+"@deskpro/app-sdk@^0.2.30":
+  version "0.2.30"
+  resolved "https://registry.yarnpkg.com/@deskpro/app-sdk/-/app-sdk-0.2.30.tgz#563f048e95c40c2d2cd53f52a5133d418724710e"
+  integrity sha512-yI6HWfM0+vZde7gRNuAXQ8t6oq2To8ZoxZaL2u8VmTBnlPaTu/nHbcczh/5HDZLQC9herY5NGJI+ol/GBJ1MkQ==
   dependencies:
     "@deskpro/deskpro-ui" "0.1.14"
     handlebars "4.7.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -384,10 +384,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@deskpro/app-sdk@^0.1.17":
-  version "0.1.17"
-  resolved "https://registry.yarnpkg.com/@deskpro/app-sdk/-/app-sdk-0.1.17.tgz#f73009ea1f3be738ba80b5e7d70d40d2715568e4"
-  integrity sha512-A9V/hIiKmBdnQLolEL7Y8BroPbM+V7nzV4wwER4lEwDCq9g8AiWpqL8OW0uRE9VTB//VN5bPxePrrzweRlraAw==
+"@deskpro/app-sdk@^0.1.23":
+  version "0.1.23"
+  resolved "https://registry.yarnpkg.com/@deskpro/app-sdk/-/app-sdk-0.1.23.tgz#e03f1fb3d99c8fde02227bf74229781554dd8299"
+  integrity sha512-4G0FsECqkWMeWuBvSQOCpNBJEV6D6+ytnWeT4KRzihP1bUxneUAoODHhyM0hfyInkqBvEggMRHBCEbsQz3Kd4w==
   dependencies:
     "@deskpro/deskpro-ui" "0.1.14"
     handlebars "4.7.7"


### PR DESCRIPTION
This PR contains the following features:

- Manage linked JIRA item reply box notes selection state
- Add Deskpro notes as JIRA comments (with optional attachments added to the JIRA issue itself, as comment attachments aren't supported)