### PR TITLE
Fixed link in issue key on the view page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "@deskpro-apps/jira",
   "title": "JIRA",
   "description": "View Jira issues linked with Deskpro tickets to streamline communication with users",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "scope": "agent",
   "isSingleInstall": true,
   "hasDevMode": true,

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -82,7 +82,7 @@ export const View: FC<ViewProps> = ({ issueKey }: ViewProps) => {
           </div>
           <Property title="Issue Key">
             {issue.key}
-            <ExternalLink href={`https://${domain}.atlassian.net/browse/${issue.projectKey}`} />
+            <ExternalLink href={`https://${domain}.atlassian.net/browse/${issue.key}`} />
           </Property>
           {issue.description && (
             <Property title="Description">


### PR DESCRIPTION
story https://app.shortcut.com/deskpro/story/78574/jira-app-link-in-issue-key-goes-to-project-when-issue-is-expanded-in-deskpro-ui