### PR TITLE
[Bug] Update deprecated endpoints causing 410 errors (SC-200180)

### DIFF
--- a/src/api/issues/listLinkedIssues/listLinkedIssues.ts
+++ b/src/api/issues/listLinkedIssues/listLinkedIssues.ts
@@ -5,18 +5,18 @@ import { findEpicLinkMeta, isCustomFieldKey, transformFieldMeta } from "@/api/ut
 import { FieldType } from "@/types";
 import { IDeskproClient } from "@deskpro/app-sdk";
 
-export default async function listLinkedIssues (
+export default async function listLinkedIssues(
   client: IDeskproClient,
-  keys: string[],
+  linkedIssueKeys: string[],
 ): Promise<IssueItem[]> {
-  if (!keys.length) {
+  if (!linkedIssueKeys.length) {
     return [];
   }
-  const issueJql = encodeURIComponent(`issueKey IN (${keys.join(",")})`);
+  const issueJql = encodeURIComponent(`issueKey IN (${linkedIssueKeys.join(",")})`);
 
   const { issues: fullIssues } = await jiraRequest<SearchIssues>(
     client,
-    {endpoint: `/search?jql=${issueJql}&expand=editmeta`},
+    { endpoint: `/search/jql?jql=${issueJql}&expand=editmeta&fields=*all` },
   )
 
   const epicKeys: Record<IssueBean["key"], FieldMeta["key"]> = (fullIssues ?? []).reduce((list, issue) => {
@@ -53,7 +53,7 @@ export default async function listLinkedIssues (
     );
     const { issues: fullEpics } = await jiraRequest<SearchIssues>(
       client,
-     {endpoint: `/search?jql=${epicJql}`}
+      { endpoint: `/search/jql?jql=${epicJql}` }
     );
 
     epics = (fullEpics ?? []).reduce((list, issue) => ({

--- a/src/api/issues/searchIssues/searchIssues.ts
+++ b/src/api/issues/searchIssues/searchIssues.ts
@@ -20,7 +20,7 @@ export default async function searchIssues(client: IDeskproClient, searchQuery: 
   const issueJql = encodeURIComponent(`issueKey IN (${keys.join(",")})`);
   const { issues: fullIssues } = await jiraRequest<SearchIssues>(
     client,
-    { endpoint: `/search?jql=${issueJql}&expand=editmeta` },
+    { endpoint: `/search/jql?jql=${issueJql}&expand=editmeta&fields=*all` },
   );
 
   const issues: Record<IssueBean["key"], IssueBean> = (fullIssues ?? []).reduce((list, issue) => ({
@@ -51,7 +51,7 @@ export default async function searchIssues(client: IDeskproClient, searchQuery: 
 
     const { issues: fullEpics } = await jiraRequest<SearchIssues>(
       client,
-      { endpoint: `/search?jql=${epicJql}` },
+      { endpoint: `/search/jql?jql=${epicJql}&fields=*all` },
     );
 
     epics = (fullEpics ?? []).reduce((list, issue) => ({
@@ -61,7 +61,7 @@ export default async function searchIssues(client: IDeskproClient, searchQuery: 
   }
 
   return (searchIssues ?? []).map((searchIssue) => {
-    const issueFields: IssueBean["fields"] = issues[searchIssue.key]?.fields;
+    const issueFields: IssueBean["fields"] | undefined = issues[searchIssue.key]?.fields;
     const epic: IssueBean | undefined = epics[epicKeys[searchIssue.key]];
 
     return {
@@ -71,12 +71,12 @@ export default async function searchIssues(client: IDeskproClient, searchQuery: 
       keyHtml: searchIssue.keyHtml,
       summary: searchIssue.summaryText,
       summaryHtml: searchIssue.summary,
-      status: issueFields.status?.name || "-",
-      projectKey: issueFields.project?.key ?? "",
-      projectName: issueFields.project?.name ?? "-",
-      reporterId: issueFields.reporter?.accountId ?? "",
-      reporterName: issueFields.reporter?.displayName ?? "-",
-      reporterAvatarUrl: (issueFields.reporter?.avatarUrls ?? {})["24x24"] ?? "",
+      status: issueFields?.status?.name || "-",
+      projectKey: issueFields?.project?.key ?? "",
+      projectName: issueFields?.project?.name ?? "-",
+      reporterId: issueFields?.reporter?.accountId ?? "",
+      reporterName: issueFields?.reporter?.displayName ?? "-",
+      reporterAvatarUrl: (issueFields?.reporter?.avatarUrls ?? {})["24x24"] ?? "",
       epicKey: epic?.key,
       epicName: epic?.fields?.summary,
     };


### PR DESCRIPTION
## Description

This PR updates deprecated search endpoints.

## Summary by Sourcery

Update Jira search API usage to new endpoints and adjust response handling to prevent errors.

Bug Fixes:
- Replace deprecated /search endpoints with /search/jql and include fields parameter to avoid 410 errors

Enhancements:
- Add optional chaining for issueFields properties to guard against undefined values
- Rename function parameter to linkedIssueKeys for improved clarity