### PR TITLE
Fixed the crash (TypeError: Cannot read properties of undefined (read…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "title": "Jira",
   "description": "View Jira issues linked with Deskpro tickets to streamline communication with users",
   "appStoreUrl": "https://www.deskpro.com/product-embed/apps/jira",
-  "version": "1.0.63",
+  "version": "1.0.74",
   "scope": "agent",
   "isSingleInstall": false,
   "hasDevMode": true,

--- a/src/api/issues/listLinkedIssues/listLinkedIssues.ts
+++ b/src/api/issues/listLinkedIssues/listLinkedIssues.ts
@@ -53,7 +53,7 @@ export default async function listLinkedIssues(
     );
     const { issues: fullEpics } = await jiraRequest<SearchIssues>(
       client,
-      { endpoint: `/search/jql?jql=${epicJql}` }
+      { endpoint: `/search/jql?jql=${epicJql}&fields=summary` }
     );
 
     epics = (fullEpics ?? []).reduce((list, issue) => ({
@@ -75,7 +75,7 @@ export default async function listLinkedIssues(
       id: issue.id,
       key: issue.key,
       epicKey: epic?.key,
-      epicName: epic?.fields.summary,
+      epicName: epic?.fields?.summary,
       status: issue.fields.status?.name || "-",
       sprints: issueSprints,
       customFields: combineCustomFieldValueAndMeta(


### PR DESCRIPTION
Fix for: https://linear.app/deskpro/issue/SR-262/jira-app-integration-fails-to-load-on-specific-ticket-due-to

## Summary by Sourcery

Prevent Jira app integration from crashing when loading linked issues for tickets with epics missing summary data.

Bug Fixes:
- Ensure Jira epic summaries are explicitly requested and safely accessed to avoid TypeError crashes in linked issues listing.

Build:
- Bump Jira app manifest version to 1.0.74.