### PR TITLE
ci: pin devcontainer pnpm to 10 (fix ERR_PNPM_IGNORED_BUILDS)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "lts",
-      "pnpm": "10"
+      "pnpmVersion": "10"
     }
   },
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "lts",
-      "pnpm": "latest"
+      "pnpm": "10"
     }
   },
   "customizations": {


### PR DESCRIPTION
## Problem

`main` CI (`build_and_tag`) fails at the devcontainer `postCreateCommand` (`pnpm install`):

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.5.1, @sentry/cli@2.58.4, @swc/core@1.15.8, core-js@3.47.0, esbuild@0.25.12
```

Nothing in the repo changed. `.devcontainer/devcontainer.json` pinned the pnpm feature to `"latest"`, which rolled to **pnpm 11**. pnpm 11 defaults `strictDepBuilds` to `true`, so ignored dependency build scripts now **hard-fail** the install (exit 1) instead of just warning as pnpm 10 did. The repo has no `onlyBuiltDependencies`/`allowBuilds` allowlist, so the install aborts and the whole job dies.

## Fix (lightest-weight)

Pin the devcontainer pnpm feature to `"10"` — reverts to warn-not-fail behavior and unblocks CI without touching dependency config.

## Follow-up (not in this PR)

Longer term, add a build-scripts allowlist to `package.json` so the repo is safe to move to pnpm 11:

```json
"pnpm": {
  "onlyBuiltDependencies": ["@parcel/watcher", "@sentry/cli", "@swc/core", "core-js", "esbuild"],
  "allowBuilds":          ["@parcel/watcher", "@sentry/cli", "@swc/core", "core-js", "esbuild"]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update devcontainer configuration to use pnpm 10 instead of the latest version to prevent ERR_PNPM_IGNORED_BUILDS failures in CI.